### PR TITLE
Added installation page logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ module-configs/*
 !module-configs/.gitkeep
 docker-compose.yml
 .ready
+ws/assets/.install

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ module-configs/*
 !module-configs/.gitkeep
 docker-compose.yml
 .ready
-ws/assets/.install
+assets/.install

--- a/assets/proxy_installing.html
+++ b/assets/proxy_installing.html
@@ -37,10 +37,14 @@
   <span class='particle'>please wait...</span>
   <article class='content'>
     <p><img src="/crest.png"></p>
+    <div class="loading" style="color: #595959;"></div>
     <p><strong>Installing</strong></p>
-    <p>Please wait while Edgebox sets the necessary components for you</p>
+    <div class="loading" style="color: #595959; margin-top: -25px; padding-bottom: 25px;"></div>
+    <p>Please wait while Edgebox is starting and configuring itself for the first time</p>
     <p>
+        <br>
     </p>
+    <p style="font-size: 10px;"><i>This will take approximately 20 minutes</i></p>
   </article>
 </main>
 <!-- partial -->
@@ -75,7 +79,17 @@
       if (value == 100) {
         clearInterval(interval);
       }
-    }, 2000);
+    }, 12000);
+
+    // How much does set interval need to take exactly 20 minutes iterating a number from 0 to 100?
+
+    // 20 minutes = 1200 seconds
+    // 1200 seconds / 100 = 12 seconds per iteration
+    // 12 seconds / 2 = 6 seconds per increment
+    // 6 seconds / 100 = 0.06 seconds per increment
+    // 0.06 seconds * 1000 = 60 milliseconds per increment
+
+
   </script>
 </body>
 </html>

--- a/assets/proxy_installing.html
+++ b/assets/proxy_installing.html
@@ -66,6 +66,7 @@
 
     var value = 0;
     var interval = setInterval(function () {
+      console.log("Progress: " + value + "%")
       value++;
       for (var i = 0; i < elements.length; i++) {
         var element = elements[i];
@@ -81,13 +82,22 @@
       }
     }, 12000);
 
-    // How much does set interval need to take exactly 20 minutes iterating a number from 0 to 100?
+    // Check with fetch if the file installing.html responds with 200 OK
+    // If it does, then we can assume that the installation is still underway
+    // If it doesn't, then we can assume that the installation is complete
 
-    // 20 minutes = 1200 seconds
-    // 1200 seconds / 100 = 12 seconds per iteration
-    // 12 seconds / 2 = 6 seconds per increment
-    // 6 seconds / 100 = 0.06 seconds per increment
-    // 0.06 seconds * 1000 = 60 milliseconds per increment
+    var interval = setInterval(function () {
+      fetch('/installing.html')
+        .then(function (response) {
+          if (response.status == 200) {
+            console.log("Installation is still underway");
+          } else {
+            console.log("Installation is complete");
+            clearInterval(interval);
+            window.location.href = "http://api.edgebox.local";
+          }
+        })
+    }, 1000);
 
 
   </script>

--- a/assets/proxy_installing.html
+++ b/assets/proxy_installing.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en" >
+<head>
+  <meta charset="UTF-8">
+  <title>EdgeBox - 404 app not found</title>
+  <link rel="stylesheet" href="/style.css">
+
+</head>
+<body>
+<!-- partial:index.partial.html -->
+<main class='container'>
+  <span class='particle'>🚀</span>
+  <span class='particle'>0%</span>
+  <span class='particle'>starting...</span>
+  <span class='particle'>0%</span>
+  <span class='particle'>😍</span>
+  <span class='particle'>0%</span>
+  <span class='particle'>getting ready...</span>
+  <span class='particle'>0%</span>
+  <span class='particle'>0%</span>
+  <span class='particle'>👋</span>
+  <span class='particle'>🚦%</span>
+  <span class='particle'>0%</span>
+  <span class='particle'>welcome!</span>
+  <span class='particle'>0%</span>
+  <span class='particle'>0%</span>
+  <span class='particle'>🤔</span>
+  <span class='particle'>0%</span>
+  <span class='particle'>0%</span>
+  <span class='particle'>thinking...</span>
+  <span class='particle'>0%</span>
+  <span class='particle'>🌟</span>
+  <span class='particle'>🤓</span>
+  <span class='particle'>🎉</span>
+  <span class='particle'>...</span>
+  <span class='particle'>...</span>
+  <span class='particle'>please wait...</span>
+  <article class='content'>
+    <p><img src="/crest.png"></p>
+    <p><strong>Installing</strong></p>
+    <p>Please wait while Edgebox sets the necessary components for you</p>
+    <p>
+    </p>
+  </article>
+</main>
+<!-- partial -->
+  <!-- <script  src="/script.js"></script> -->
+  <script>
+    console.log('Gradually incrementing particle value for all elements...');
+    var elements = document.getElementsByClassName('particle');
+
+    // Make all particles have an annimation effect of a smoothly moving gradient color as their font color
+    setInterval(() => {
+      for (var i = 0; i < elements.length; i++) {
+        var element = elements[i];
+        element.style.color = 'hsl(' + Math.floor(Math.random() * 360) + ', 100%, 50%)';
+        element.style.animation = 'color-change 2s infinite';
+        // It should have a gradual transition from one color to the other
+        element.style.transition = 'color 2s';
+      }
+    }, 100);
+
+    var value = 0;
+    var interval = setInterval(function () {
+      value++;
+      for (var i = 0; i < elements.length; i++) {
+        var element = elements[i];
+        element.innerHTML = value + '%';
+        // There is a one in 30 change that this element turns into a random emoji in a list
+        var emoji_list = ['🚀', '👋', '🤔', '🌟', '🤓', '🎉', '🚦', '😍'];
+        if (Math.floor(Math.random() * 30) == 0) {
+          element.innerHTML = emoji_list[Math.floor(Math.random() * emoji_list.length)];
+        }
+      }
+      if (value == 100) {
+        clearInterval(interval);
+      }
+    }, 2000);
+  </script>
+</body>
+</html>

--- a/assets/style.css
+++ b/assets/style.css
@@ -665,3 +665,30 @@ body {
     transform: translateY(-28px);
   }
 }
+
+.loading {
+  font-size: 30px;
+  color: #595959;
+}
+
+.loading:after {
+  overflow: hidden;
+  display: inline-block;
+  vertical-align: bottom;
+  -webkit-animation: ellipsis steps(4,end) 900ms infinite;      
+  animation: ellipsis steps(4,end) 900ms infinite;
+  content: "\2026"; /* ascii code for the ellipsis character */
+  width: 0px;
+}
+
+@keyframes ellipsis {
+  to {
+    width: 1.25em;    
+  }
+}
+
+@-webkit-keyframes ellipsis {
+  to {
+    width: 1.25em;    
+  }
+}

--- a/proxy.conf
+++ b/proxy.conf
@@ -26,9 +26,13 @@ server {
     server_name localhost;
 
     location / {
-        if (-f /usr/share/nginx/html/.install) {
+        if (-f /usr/share/nginx/html/installing.html) {
                 return 503;
         }
+    }
+
+    location = /installing.html {
+            root /usr/share/nginx/html;
     }
 
     location = /style.css {

--- a/proxy.conf
+++ b/proxy.conf
@@ -25,11 +25,21 @@ server {
 
     server_name localhost;
 
+    location / {
+        if (-f /usr/share/nginx/html/.install) {
+                return 503;
+        }
+    }
+
     location = /style.css {
             root /usr/share/nginx/html;
     }
     
     location = /crest.png {
+            root /usr/share/nginx/html;
+    }
+
+    location = /script.js {
             root /usr/share/nginx/html;
     }
 
@@ -39,8 +49,14 @@ server {
             internal;
     }
 
-    error_page 500 502 503 504 /proxy_50x.html;
+    error_page 500 502 504 /proxy_50x.html;
     location = /proxy_50x.html {
+            root /usr/share/nginx/html;
+            internal;
+    }
+
+    error_page 503 /proxy_installing.html;
+    location = /proxy_installing.html {
             root /usr/share/nginx/html;
             internal;
     }


### PR DESCRIPTION
This PR adds a rewrite to a new `proxy_installing.html` page that will display while the rest of the system is still installing. This is accomplished by creating a `.install` lockfile in the nginx html root (`/assets/`) when the installation starts and right before the proxy is running, and in the end of the installation, when the dashboard is available and the user can be redirected there.